### PR TITLE
Feat/db-exporter-retry-logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Information stealers are malwares that steal sensitive data, aka **logs**, to be sold in forums or shared in chat groups.
 
-This tool takes a **logs archive**, parses it, and produces a JSON file.
+This tool takes a **logs archive**, parses it, and exports to a PostgreSQL database by default, with optional JSON output.
 
 ## Table of Content
 
@@ -24,8 +24,8 @@ This tool takes a **logs archive**, parses it, and produces a JSON file.
 
 ### Output Options
 
-- **JSON Export** (default): Structured JSON files for easy integration
-- **PostgreSQL Database**: Direct export to PostgreSQL for advanced querying and analysis
+- **PostgreSQL Database** (default): Direct export for advanced querying and analysis
+- **JSON Export** (optional via `--dump-json`): Structured JSON files for easy integration
 
 See [Database Export Documentation](docs/database_export.md) for detailed database setup and usage instructions.
 
@@ -114,7 +114,7 @@ DB_CREATE_TABLES=false
 # Parser
 PREFER_DEFINITION_PARSERS=false
 RECORD_DEFINITIONS_DIRS=record_definitions
-PARSER_MATCH_THRESHOLD=2.0
+PARSER_MATCH_THRESHOLD=0.15
 ```
 
 ## Usage
@@ -136,12 +136,13 @@ options:
   -v, --verbose         increase logs output verbosity (default: info, -v: verbose, -vv: debug, -vvv: spam)
 ```
 
-Basic use:
+Basic use (DB export by default):
 
 ```console
 $ stealer_parser myfile.rar
 2024-07-08 13:37:00 - StealerParser - INFO - Processing: myfile.rar ...
-2024-07-08 13:37:00 - StealerParser - INFO - Successfully wrote 'myfile.json'.
+2024-07-08 13:37:00 - StealerParser - INFO - Exporting myfile.rar to database...
+2024-07-08 13:37:00 - StealerParser - INFO - Database export completed successfully: 3 systems, 192 credentials, 156 cookies, 0 vaults, 0 user_files exported
 ```
 
 Use the verbose option to display extra information:
@@ -150,7 +151,8 @@ Use the verbose option to display extra information:
 $ stealer_parser -vvv myfile.zip
 2024-07-08 13:37:00 - StealerParser - INFO - Processing: myfile.zip ...
 2024-07-08 13:37:00 - StealerParser - DEBUG - Parsed 'myfile.zip' (983 systems).
-2024-07-08 13:37:00 - StealerParser - INFO - Successfully wrote 'myfile.json'.
+2024-07-08 13:37:00 - StealerParser - INFO - Exporting myfile.zip to database...
+2024-07-08 13:37:00 - StealerParser - INFO - Database export completed successfully: ...
 ```
 
 Open password-protected archives:
@@ -159,7 +161,7 @@ Open password-protected archives:
 $ stealer_parser myfile.zip --password mypassword
 ```
 
-Choose output file name:
+Also dump JSON:
 
 ```console
 $ stealer_parser myfile.zip --dump-json results/foo.json
@@ -183,7 +185,7 @@ $ stealer_parser myfile.rar --dump-json ./results/foo.json
 
 ## Documentation
 
-The grammars can be found in the [`docs` directory](docs).
+The grammars and feature docs can be found in the [`docs` directory](docs). See [Database Export Documentation](docs/database_export.md) for DB setup, performance, logging, and troubleshooting.
 
 ## Contributing
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ pydantic-settings = "^2.10.1"
 PyYAML = "^6.0.2"
 
 [tool.poetry.scripts]
-stealer_parser = "stealer_parser.main:main"
+stealer_parser = "stealer_parser.main:cli"
 
 [tool.poetry.group.dev.dependencies]
 pre-commit = "^3.7.1"

--- a/stealer_parser/config.py
+++ b/stealer_parser/config.py
@@ -29,7 +29,7 @@ class Settings(BaseSettings):
     db_create_tables: bool = False
 
     # Parser feature flags and configuration
-    prefer_definition_parsers: bool = False
+    prefer_definition_parsers: bool = True
     record_definitions_dirs: List[str] = ["record_definitions"]
     parser_match_threshold: float = 0.15
     

--- a/stealer_parser/database/dao/credential_cookie.py
+++ b/stealer_parser/database/dao/credential_cookie.py
@@ -63,7 +63,16 @@ class CredentialCookieDAO(BaseDAO):
         WHERE c.host LIKE %(host_pattern)s
         ORDER BY s.id, c.id, ck.id;
         """
-        return self._execute_query(query, {"host_pattern": f"%{host_pattern}%"}, fetch="all")
+        return self._execute_query(
+            query,
+            {"host_pattern": f"%{host_pattern}%"},
+            fetch="all",
+            ctx={
+                "dao": "CredentialCookieDAO",
+                "action": "find_matches",
+                "host_pattern": host_pattern,
+            },
+        )
 
     def insert(self, *args: Any) -> int:
         """Not implemented for this read-only DAO."""

--- a/stealer_parser/database/dao/user_file.py
+++ b/stealer_parser/database/dao/user_file.py
@@ -26,7 +26,19 @@ class UserFilesDAO(BaseDAO):
             data.detected_patterns,
             data.stealer_name,
         )
-        return self._execute_query(query, params, conn=conn)
+        return self._execute_query(
+            query,
+            params,
+            conn=conn,
+            ctx={
+                "dao": "UserFilesDAO",
+                "action": "insert",
+                "table": "user_files",
+                "system_id": system_id,
+                "file_path": data.file_path,
+                "size": data.file_size,
+            },
+        )
 
     def bulk_insert(self, *args: Any, conn=None) -> int:
         data: List[UserFile] = args[0]
@@ -48,4 +60,15 @@ class UserFilesDAO(BaseDAO):
             )
             for uf in data
         ]
-        return self._execute_values(query, params, conn=conn)
+        return self._execute_values(
+            query,
+            params,
+            conn=conn,
+            ctx={
+                "dao": "UserFilesDAO",
+                "action": "bulk_insert",
+                "table": "user_files",
+                "system_id": system_id,
+                "rows": len(data),
+            },
+        )

--- a/stealer_parser/database/dao/vault.py
+++ b/stealer_parser/database/dao/vault.py
@@ -39,7 +39,19 @@ class VaultDAO(BaseDAO):
             str(data.filepath) if data.filepath else None,
             data.stealer_name,
         )
-        return self._execute_query(query, params, conn=conn)
+        return self._execute_query(
+            query,
+            params,
+            conn=conn,
+            ctx={
+                "dao": "VaultDAO",
+                "action": "insert",
+                "table": "vaults",
+                "system_id": system_id,
+                "vault_type": data.vault_type,
+                "filepath": str(data.filepath) if data.filepath else None,
+            },
+        )
 
     def bulk_insert(self, *args: Any, conn=None) -> int:
         data: List[Vault] = args[0]
@@ -71,4 +83,15 @@ class VaultDAO(BaseDAO):
             )
             for v in data
         ]
-        return self._execute_values(query, params, conn=conn)
+        return self._execute_values(
+            query,
+            params,
+            conn=conn,
+            ctx={
+                "dao": "VaultDAO",
+                "action": "bulk_insert",
+                "table": "vaults",
+                "system_id": system_id,
+                "rows": len(data),
+            },
+        )

--- a/stealer_parser/main.py
+++ b/stealer_parser/main.py
@@ -105,6 +105,21 @@ def main(
         if archive:
             archive.close()
 
+
+def cli() -> None:
+    """Console script entrypoint that initializes DI and invokes main."""
+    app_container = AppContainer()
+    app_container.wire(modules=[__name__])
+    app_container.init_resources()
+    try:
+        logger = app_container.logger()
+        leak_processor = app_container.leak_processor()
+        db_exporter = app_container.services.postgres_exporter()
+        settings = app_container.config()
+        main(logger=logger, leak_processor=leak_processor, db_exporter=db_exporter, settings=settings)
+    finally:
+        app_container.shutdown_resources()
+
 def export_to_database(
     db_exporter: PostgreSQLExporter,
     logger: VerboseLogger,
@@ -153,19 +168,4 @@ def export_to_database(
 
 
 if __name__ == "__main__":
-    # Initialize DI container
-    app_container = AppContainer()
-
-    app_container.wire(modules=[__name__])
-    # Initialize resources (e.g., DB pool)
-    app_container.init_resources()
-    try:
-        # Resolve dependencies explicitly to avoid unresolved Provide objects
-        logger = app_container.logger()
-        leak_processor = app_container.leak_processor()
-        db_exporter = app_container.services.postgres_exporter()
-        settings = app_container.config()
-        main(logger=logger, leak_processor=leak_processor, db_exporter=db_exporter, settings=settings)
-    finally:
-        # Ensure resources are cleaned up
-        app_container.shutdown_resources()
+    cli()


### PR DESCRIPTION
- Enhanced `export_leak` method to include error handling for bulk inserts of credentials, cookies, vaults, and user files, with fallbacks to row-by-row inserts.
- Updated database schema to create a unified view `v_system_profile_records` for cross-entity queries across credentials, cookies, and vaults.
- Modified `init_logger` to accept verbosity level as an integer and adjusted logging levels accordingly.
- Improved parser selection and processing logic to handle leading banner lines in text files.
- Added tests for banner handling, cookie parsing, credential profile fields, and trimming of key-value pairs.
- Introduced a new DAO `ProfileViewDAO` for querying the unified view.
- Documented parser pipeline overview for better understanding of record type detection and processing flow.